### PR TITLE
Use uint64 for max memory config parameter

### DIFF
--- a/.pipelines/build-pipeline.yaml
+++ b/.pipelines/build-pipeline.yaml
@@ -8,7 +8,7 @@ trigger:
 - release/*
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'Ubuntu-18.04'
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
@@ -20,7 +20,7 @@ steps:
 
 - task: Docker@2
   displayName: Login to ACR
-  inputs: 
+  inputs:
     command: login
     containerRegistry: $(DockerRegistryConnectionID)
 
@@ -30,7 +30,7 @@ steps:
 
 - task: Docker@2
   displayName: Build and push docker image
-  inputs: 
+  inputs:
     command: buildAndPush
     dockerfile: '$(modulePath)/docker/operator/Dockerfile'
     buildContext: '$(modulePath)/bin'
@@ -54,6 +54,6 @@ steps:
 
 - task: Docker@2
   displayName: Logout from ACR
-  inputs: 
+  inputs:
     command: logout
     containerRegistry: $(DockerRegistryConnectionID)

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -40,7 +40,7 @@ type Redis struct {
 	ServerBin          string
 	ServerPort         string
 	ServerIP           string
-	MaxMemory          uint32
+	MaxMemory          uint64
 	MaxMemoryPolicy    string
 	ConfigFiles        []string
 }
@@ -52,7 +52,7 @@ func (r *Redis) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&r.ConfigFileName, "c", RedisConfigFileDefault, "redis config file path")
 	fs.StringVar(&r.renameCommandsPath, "rename-command-path", RedisRenameCommandsDefaultPath, "Path to the folder where rename-commands option for redis are available")
 	fs.StringVar(&r.renameCommandsFile, "rename-command-file", RedisRenameCommandsDefaultFile, "Name of the file where rename-commands option for redis are available, disabled if empty")
-	fs.Uint32Var(&r.MaxMemory, "max-memory", RedisMaxMemoryDefault, "redis max memory")
+	fs.Uint64Var(&r.MaxMemory, "max-memory", RedisMaxMemoryDefault, "redis max memory")
 	fs.StringVar(&r.MaxMemoryPolicy, "max-memory-policy", RedisMaxMemoryPolicyDefault, "redis max memory evition policy")
 	fs.StringVar(&r.ServerBin, "bin", RedisServerBinDefault, "redis server binary file name")
 	fs.StringVar(&r.ServerPort, "port", RedisServerPortDefault, "redis server listen port")


### PR DESCRIPTION
The `max-memory` parameter uses an unit32, which makes the max value of ~4GB. So we cannot set a larger `max-memory`